### PR TITLE
System Update Information

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -47,6 +47,7 @@ jobs:
                *.ELF
 ####################################################### 
   build-spanish:
+    if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     needs: build
     container: ps2dev/ps2dev:v1.0

--- a/main.c
+++ b/main.c
@@ -841,7 +841,7 @@ static void ShowDebugInfo(void)
 				sprintf(TextRow, "argv[%d] == \"%s\"", i, boot_argv[i]);
 				PrintRow(-1, TextRow);
 			}
-			sprintf(TextRow, "System Update KELF == \"%s\"",default_OSDSYS_path2);
+			sprintf(TextRow, "System Update KELF == \"%s\"",strchr(default_OSDSYS_path2,'/')+ 1);
 			PrintRow(-1, TextRow);
 			sprintf(TextRow, "boot_path == \"%s\"", boot_path);
 			PrintRow(-1, TextRow);

--- a/main.c
+++ b/main.c
@@ -839,9 +839,9 @@ static void ShowDebugInfo(void)
 				sprintf(TextRow, "argv[%d] == \"%s\"", i, boot_argv[i]);
 				PrintRow(-1, TextRow);
 			}
-			sprintf(TextRow, "System Update Folder == ",GetMGFolderLetter(ROMVER_data[4]));
+			sprintf(TextRow, "System Update Folder == %s",GetMGFolderLetter(ROMVER_data[4]));
 			PrintRow(-1, TextRow);
-			sprintf(TextRow, "System Update KELF == ",strrchr(default_OSDSYS_path,'/') + 1);
+			sprintf(TextRow, "System Update KELF == %s",strrchr(default_OSDSYS_path,'/') + 1);
 			PrintRow(-1, TextRow);
 			sprintf(TextRow, "boot_path == \"%s\"", boot_path);
 			PrintRow(-1, TextRow);

--- a/main.c
+++ b/main.c
@@ -759,6 +759,27 @@ static void load_smbman(void)
 //---------------------------------------------------------------------------
 #include "SMB_test.c"
 #endif
+char* GetMGFolderLetter(char region){
+	char err[10] = "ERROR (R)"
+	switch(region){
+		case 'C':
+			return "BCEXEC-SYSTEM";
+			break;
+		case 'J':
+			return "BIEXEC-SYSTEM";
+			break;
+		case 'H':
+		case 'A':
+			return "BAEXEC-SYSTEM";
+			break;
+		case 'E':
+			return "BEEXEC-SYSTEM";
+			break;
+		default:
+			sprintf(err,"ERROR (%c)",region);
+			return err;
+	}
+}
 //---------------------------------------------------------------------------
 //Function to show a screen with debugging info
 //------------------------------
@@ -818,6 +839,10 @@ static void ShowDebugInfo(void)
 				sprintf(TextRow, "argv[%d] == \"%s\"", i, boot_argv[i]);
 				PrintRow(-1, TextRow);
 			}
+			sprintf(TextRow, "System Update Folder == ",GetMGFolderLetter(ROMVER_data[4]);
+			PrintRow(-1, TextRow);
+			sprintf(TextRow, "System Update KELF == ",strrchr(default_OSDSYS_path,'/') + 1);
+			PrintRow(-1, TextRow);
 			sprintf(TextRow, "boot_path == \"%s\"", boot_path);
 			PrintRow(-1, TextRow);
 			sprintf(TextRow, "LaunchElfDir == \"%s\"", LaunchElfDir);

--- a/main.c
+++ b/main.c
@@ -846,7 +846,7 @@ static void ShowDebugInfo(void)
 			PrintRow(-1, TextRow);
 			if (ROMVersion > 0x130)
 			{
-				sprintf(TextRow, "Specific System Update KELF == \"B%cEXEC-SYSTEM/osd%03x.elf\"", rough_region, (ROMVersion+0x10)&~0x0F);
+				sprintf(TextRow, "Specific System Update KELF == \"B%cEXEC-SYSTEM/osd%03x.elf\"", rough_region, (ROMVersion)&~0x0F);
 				PrintRow(-1, TextRow);
 			}
 			sprintf(TextRow, "boot_path == \"%s\"", boot_path);
@@ -2148,7 +2148,7 @@ static void InitializeBootExecPath()
 
 	sprintf( default_OSDSYS_path, "mc:/B%cEXEC-SYSTEM/%s", rough_region, file);
 	if ( ROMVersion  >= 0x230 )
-		sprintf(default_OSDSYS_path2, "Incompatible Unit (0x%03x)", (ROMVersion+0x10)&~0x0F);
+		sprintf(default_OSDSYS_path2, "Incompatible Unit (0x%03x)", (ROMVersion)&~0x0F);
 	else
 		sprintf(default_OSDSYS_path2, "mc:/B%cEXEC-SYSTEM/%s", rough_region, file);
 

--- a/main.c
+++ b/main.c
@@ -842,9 +842,9 @@ static void ShowDebugInfo(void)
 				sprintf(TextRow, "argv[%d] == \"%s\"", i, boot_argv[i]);
 				PrintRow(-1, TextRow);
 			}
-			sprintf(TextRow, "Main System Update KELF == \"%s\"",strchr(default_OSDSYS_path2,'/')+ 1);
+			sprintf(TextRow,     "Main System Update KELF     == \"%s\"",strchr(default_OSDSYS_path2,'/')+ 1);
 			PrintRow(-1, TextRow);
-			if (ROMVersion > 0x130)
+			if (0x230 < ROMVersion > 0x130)
 			{
 				sprintf(TextRow, "Specific System Update KELF == \"B%cEXEC-SYSTEM/osd%03x.elf\"", rough_region, (ROMVersion)&~0x0F);
 				PrintRow(-1, TextRow);

--- a/main.c
+++ b/main.c
@@ -839,7 +839,7 @@ static void ShowDebugInfo(void)
 				sprintf(TextRow, "argv[%d] == \"%s\"", i, boot_argv[i]);
 				PrintRow(-1, TextRow);
 			}
-			sprintf(TextRow, "System Update Folder == ",GetMGFolderLetter(ROMVER_data[4]);
+			sprintf(TextRow, "System Update Folder == ",GetMGFolderLetter(ROMVER_data[4]));
 			PrintRow(-1, TextRow);
 			sprintf(TextRow, "System Update KELF == ",strrchr(default_OSDSYS_path,'/') + 1);
 			PrintRow(-1, TextRow);

--- a/main.c
+++ b/main.c
@@ -844,7 +844,7 @@ static void ShowDebugInfo(void)
 			}
 			sprintf(TextRow,     "Main System Update KELF     == \"%s\"",strchr(default_OSDSYS_path2,'/')+ 1);
 			PrintRow(-1, TextRow);
-			if ((0x230 < ROMVersion) && (ROMVersion > 0x130))
+			if ((ROMVersion < 0x230) && (ROMVersion > 0x130))
 			{
 				sprintf(TextRow, "Specific System Update KELF == \"B%cEXEC-SYSTEM/osd%03x.elf\"", rough_region, (ROMVersion)&~0x0F);
 				PrintRow(-1, TextRow);

--- a/main.c
+++ b/main.c
@@ -760,8 +760,8 @@ static void load_smbman(void)
 #include "SMB_test.c"
 #endif
 char* GetMGFolderLetter(char region){
-	char err[10] = "ERROR (R)"
-	switch(region){
+	char err[10] = "ERROR (R)";
+	switch (region) {
 		case 'C':
 			return "BCEXEC-SYSTEM";
 			break;

--- a/main.c
+++ b/main.c
@@ -153,6 +153,7 @@ char SystemCnf_VMODE[10];  //Arbitrary, same deal. As yet unused
 char default_ESR_path[] = "mc:/BOOT/ESR.ELF";
 char default_OSDSYS_path[30];
 char default_OSDSYS_path2[30];
+static unsigned short int ROMVersion;
 
 char ROMVER_data[16];  //16 byte file read from rom0:ROMVER at init
 char rough_region;     //E==Europe, A==US, I==Japan, H==Asia, C==China
@@ -841,8 +842,13 @@ static void ShowDebugInfo(void)
 				sprintf(TextRow, "argv[%d] == \"%s\"", i, boot_argv[i]);
 				PrintRow(-1, TextRow);
 			}
-			sprintf(TextRow, "System Update KELF == \"%s\"",strchr(default_OSDSYS_path2,'/')+ 1);
+			sprintf(TextRow, "Main System Update KELF == \"%s\"",strchr(default_OSDSYS_path2,'/')+ 1);
 			PrintRow(-1, TextRow);
+			if (ROMVersion > 0x130)
+			{
+				sprintf(TextRow, "Specific System Update KELF == \"B%cEXEC-SYSTEM/osd%03x.elf\"", rough_region, (ROMVersion+0x10)&~0x0F);
+				PrintRow(-1, TextRow);
+			}
 			sprintf(TextRow, "boot_path == \"%s\"", boot_path);
 			PrintRow(-1, TextRow);
 			sprintf(TextRow, "LaunchElfDir == \"%s\"", LaunchElfDir);
@@ -2109,7 +2115,6 @@ static void InitializeBootExecPath()
 {
 	char file[12];
 
-	unsigned short int ROMVersion;
 	uLE_InitializeRegion();
 	char RONVER[4 + 1];
 	strncpy(RONVER,ROMVER_data,4);

--- a/main.c
+++ b/main.c
@@ -841,9 +841,7 @@ static void ShowDebugInfo(void)
 				sprintf(TextRow, "argv[%d] == \"%s\"", i, boot_argv[i]);
 				PrintRow(-1, TextRow);
 			}
-			sprintf(TextRow, "System Update Folder == %s",GetMGFolderLetter(ROMVER_data[4]));
-			PrintRow(-1, TextRow);
-			sprintf(TextRow, "System Update KELF == %s",strrchr(default_OSDSYS_path,'/') + 1);
+			sprintf(TextRow, "System Update KELF == \"%s\"",default_OSDSYS_path2);
 			PrintRow(-1, TextRow);
 			sprintf(TextRow, "boot_path == \"%s\"", boot_path);
 			PrintRow(-1, TextRow);

--- a/main.c
+++ b/main.c
@@ -152,6 +152,7 @@ char SystemCnf_VMODE[10];  //Arbitrary, same deal. As yet unused
 
 char default_ESR_path[] = "mc:/BOOT/ESR.ELF";
 char default_OSDSYS_path[30];
+char default_OSDSYS_path2[30];
 
 char ROMVER_data[16];  //16 byte file read from rom0:ROMVER at init
 char rough_region;     //E==Europe, A==US, I==Japan, H==Asia, C==China
@@ -759,6 +760,7 @@ static void load_smbman(void)
 //---------------------------------------------------------------------------
 #include "SMB_test.c"
 #endif
+/*
 char* GetMGFolderLetter(char region){
 	char err[10] = "ERROR (R)";
 	switch (region) {
@@ -779,7 +781,7 @@ char* GetMGFolderLetter(char region){
 			sprintf(err,"ERROR (%c)",region);
 			return err;
 	}
-}
+}*/
 //---------------------------------------------------------------------------
 //Function to show a screen with debugging info
 //------------------------------
@@ -2109,8 +2111,12 @@ static void InitializeBootExecPath()
 {
 	char file[12];
 
+	unsigned short int ROMVersion;
 	uLE_InitializeRegion();
-
+	char RONVER[4 + 1];
+	strncpy(RONVER,ROMVER_data,4);
+	RONVER[4] = '\0';
+	ROMVersion = strtoul(RONVER, NULL, 16);
 	//Handle special cases, before osdmain.elf was supported.
 	switch (ROMVER_data[4]) {
 		case 'E':
@@ -2137,7 +2143,12 @@ static void InitializeBootExecPath()
 			strcpy(file, "osdmain.elf");
 	}
 
-	sprintf(default_OSDSYS_path, "mc:/B%cEXEC-SYSTEM/%s", rough_region, file);
+	sprintf( default_OSDSYS_path, "mc:/B%cEXEC-SYSTEM/%s", rough_region, file);
+	if ( ROMVersion  >= 0x230 )
+		sprintf(default_OSDSYS_path2, "Incompatible Unit (0x%03x)", (ROMVersion+0x10)&~0x0F);
+	else
+		sprintf(default_OSDSYS_path2, "mc:/B%cEXEC-SYSTEM/%s", rough_region, file);
+
 }
 //------------------------------
 //endfunc InitializeBootExecPath

--- a/main.c
+++ b/main.c
@@ -844,7 +844,7 @@ static void ShowDebugInfo(void)
 			}
 			sprintf(TextRow,     "Main System Update KELF     == \"%s\"",strchr(default_OSDSYS_path2,'/')+ 1);
 			PrintRow(-1, TextRow);
-			if (0x230 < ROMVersion > 0x130)
+			if ((0x230 < ROMVersion) && (ROMVersion > 0x130))
 			{
 				sprintf(TextRow, "Specific System Update KELF == \"B%cEXEC-SYSTEM/osd%03x.elf\"", rough_region, (ROMVersion)&~0x0F);
 				PrintRow(-1, TextRow);

--- a/main.c
+++ b/main.c
@@ -842,7 +842,7 @@ static void ShowDebugInfo(void)
 				sprintf(TextRow, "argv[%d] == \"%s\"", i, boot_argv[i]);
 				PrintRow(-1, TextRow);
 			}
-			sprintf(TextRow,     "Main System Update KELF     == \"%s\"",strchr(default_OSDSYS_path2,'/')+ 1);
+			sprintf(TextRow,     "Main System Update KELF == \"%s\"",strchr(default_OSDSYS_path2,'/')+ 1);
 			PrintRow(-1, TextRow);
 			if ((ROMVersion < 0x230) && (ROMVersion > 0x130))
 			{
@@ -2148,7 +2148,7 @@ static void InitializeBootExecPath()
 
 	sprintf( default_OSDSYS_path, "mc:/B%cEXEC-SYSTEM/%s", rough_region, file);
 	if ( ROMVersion  >= 0x230 )
-		sprintf(default_OSDSYS_path2, "Incompatible Unit (0x%03x)", (ROMVersion)&~0x0F);
+		sprintf(default_OSDSYS_path2, "/Incompatible Unit (0x%03x)", (ROMVersion)&~0x0F);
 	else
 		sprintf(default_OSDSYS_path2, "mc:/B%cEXEC-SYSTEM/%s", rough_region, file);
 


### PR DESCRIPTION
now `MISC/Info Debug` will show data related to the system update paths used by the console running the program.

It will show you:

General System Update path _(will be the actual path or the following message if console is incompatible: `Incompatible Unit (0xROMVER`)_

If the console supports `B?EXEC-SYSTEM/osmain.elf` the specific system update will be shown (ie: `B?EXEC-SYSTEM/osd180.elf`)