### PR TITLE
forbid formatting internal HDD on PSX DESR

### DIFF
--- a/src/hdd.c
+++ b/src/hdd.c
@@ -361,6 +361,9 @@ int MenuParty(PARTYINFO Info)
 	unmountParty(1);  //unconditionally unmount secondary mountpoint
 
 	memset(enable, TRUE, NUM_MENU);
+	if (console_is_PSX) {
+		enable[FORMAT] = FALSE;
+	}
 
 	if ((Info.Name[0] == '_') && (Info.Name[1] == '_')) {
 		enable[REMOVE] = FALSE;

--- a/src/main.c
+++ b/src/main.c
@@ -2551,9 +2551,10 @@ int main(int argc, char *argv[])
 
 	Reset();
 	Init_Default_Language();
-	if (exists("rom0:PSXVER"))
+	if (exists("rom0:PSXVER")) {
 		console_is_PSX = 1;
-	DPRINTF("is PSX = %d\n", console_is_PSX);
+		DPRINTF("# Console is PSX-DESR\n");
+	}
 	LaunchElfDir[0] = 0;
 	boot_path[0] = 0;
 


### PR DESCRIPTION
mostly because some noobs format the HDD on PSX while game area is not expanded, resulting in hdd damage because program made partitions wich a size that doesnt fit APA standards (partition sizes wich are not a multiple of 128mb)