### PR TITLE
Hide `mc1:/` if MX4SIO driver loaded successfully

### DIFF
--- a/include/launchelf.h
+++ b/include/launchelf.h
@@ -213,6 +213,10 @@ extern int GUI_active;  // Skin and Main Skin switch
 extern int cdmode;      //Last detected disc type
 extern u8 console_is_PSX;
 
+#ifdef MX4SIO
+extern u8 mx4sio_driver_running;
+#endif
+
 void load_vmc_fs(void);
 #ifdef ETH
 void load_ps2host(void);

--- a/src/filer.c
+++ b/src/filer.c
@@ -3484,8 +3484,15 @@ int setFileList(const char *path, const char *ext, FILEINFO *files, int cnfmode)
 
 		strcpy(files[nfiles].name, "mc0:");
 		files[nfiles++].stats.AttrFile = sceMcFileAttrSubdir;
+		
+#ifdef MX4SIO
+		if (!mx4sio_driver_running) {
+#endif
 		strcpy(files[nfiles].name, "mc1:");
 		files[nfiles++].stats.AttrFile = sceMcFileAttrSubdir;
+#ifdef MX4SIO
+		}
+#endif
 		strcpy(files[nfiles].name, "hdd0:");
 		files[nfiles++].stats.AttrFile = sceMcFileAttrSubdir;
 #ifdef DVRP

--- a/src/main.c
+++ b/src/main.c
@@ -157,7 +157,7 @@ static u8 have_Flash_modules = 0;
 #endif
 
 #ifdef MX4SIO
-static u8 mx4sio_driver_running = 0;
+u8 mx4sio_driver_running = 0;
 #endif
 
 //State of whether DEV9 was successfully loaded or not.

--- a/src/main.c
+++ b/src/main.c
@@ -155,6 +155,11 @@ static u8 have_vmc_fs = 0;
 #ifdef XFROM
 static u8 have_Flash_modules = 0;
 #endif
+
+#ifdef MX4SIO
+static u8 mx4sio_driver_running = 0;
+#endif
+
 //State of whether DEV9 was successfully loaded or not.
 static u8 ps2dev9_loaded = 0;
 

--- a/src/main.c
+++ b/src/main.c
@@ -1420,6 +1420,7 @@ static void loadUsbModules(void)
 #ifdef MX4SIO
 	ID = SifExecModuleBuffer(mx4sio_bd_irx, size_mx4sio_bd_irx, 0, NULL, &ret);
 	DPRINTF(" [MX4SIO_BD] ID=%d, ret=%d\n", ID, ret);
+	mx4sio_driver_running = (ID > 0 && ret != 1);
 #endif
 }
 #else


### PR DESCRIPTION
Because MX4SIO hooks into SIO2MAN in a way that mc1:/ cant read real Memory cards.

therefore, lock away `mc1:/` to avoid users complain such as

> `mc1:/` cant be readed