### PR TITLE
add `ioptrap.irx` build option for debugging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -143,6 +143,11 @@ else
 EE_CFLAGS += -DCUSTOM_COLORS
 endif
 
+ifeq ($(IOPTRAP),1)
+    EE_OBJS += ioptrap_irx.o
+    EE_CFLAGS += -DIOPTRAP
+endif
+
 
 EE_OBJS_DIR = obj/
 EE_ASM_DIR = asm/

--- a/embed.make
+++ b/embed.make
@@ -50,6 +50,9 @@ iop/cdvd.irx: iop/oldlibs/libcdvd
 $(EE_ASM_DIR)cdvd_irx.s: iop/cdvd.irx | $(EE_ASM_DIR)
 	$(BIN2S) $< $@ cdvd_irx
 
+$(EE_ASM_DIR)ioptrap_irx.s: $(PS2SDK)/iop/irx/ioptrap.irx | $(EE_ASM_DIR)
+	$(BIN2S) $< $@ ioptrap_irx
+
 $(EE_ASM_DIR)poweroff_irx.s: $(PS2SDK)/iop/irx/poweroff.irx | $(EE_ASM_DIR)
 	$(BIN2S) $< $@ poweroff_irx
 

--- a/src/main.c
+++ b/src/main.c
@@ -20,6 +20,10 @@ IMPORT_BIN2C(ps2netfs_irx);
 IMPORT_BIN2C(ps2ftpd_irx);
 #endif
 
+#ifdef IOPTRAP
+IMPORT_BIN2C(ioptrap_irx);
+#endif
+
 #ifdef SMB
 IMPORT_BIN2C(smbman_irx);
 #endif
@@ -1121,6 +1125,11 @@ static void load_ps2netfs(void)
 static void loadBasicModules(void)
 {
 	int ret, id;
+
+#ifdef IOPTRAP
+	id = SifExecModuleBuffer(ioptrap_irx, size_ioptrap_irx, 0, NULL, &ret);
+	DPRINTF(" [IOP TRAP]: id=%d ret=%d\n", id, ret);
+#endif
 
 	id = SifExecModuleBuffer(iomanx_irx, size_iomanx_irx, 0, NULL, &ret);
 	DPRINTF(" [IOMANX]: id=%d ret=%d\n", id, ret);


### PR DESCRIPTION
an IOP exception handler. usually to be paired with UDPTTY or PPCTTY